### PR TITLE
Add login callback, Update navbar guide

### DIFF
--- a/fire_alarm_system/lib/controllers/navigation_bar_controller.dart
+++ b/fire_alarm_system/lib/controllers/navigation_bar_controller.dart
@@ -23,6 +23,7 @@ class _NavigationBarControllerState extends State<NavigationBarController> {
     Icons.notifications,
     Icons.bar_chart,
     Icons.person,
+    Icons.home,
   ];
 
   @override
@@ -37,6 +38,7 @@ class _NavigationBarControllerState extends State<NavigationBarController> {
       RoomView(),
       EditThreshold(),
       SignoutScreen(),
+      NestedTabBar(),//thay trang moi vao cho nay, dung them moi vao vi navBar chi cho max 5 icon thoi
     ];
   }
   @override

--- a/fire_alarm_system/lib/main.dart
+++ b/fire_alarm_system/lib/main.dart
@@ -68,14 +68,6 @@ void checkGasThreshold(List<MqttReceivedMessage<MqttMessage>> c) {
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
-  warningDataStream = UserService.getFireThresholdStream();
-  warningDataStream.listen((event) {
-    warningThreshold = event;
-  });
-  fireDataStream = UserService.getFireThresholdStream();
-  fireDataStream.listen((event) {
-    fireThreshold = event;
-  });
 
   CONFIG.Config.gasSensorClient = await mqttsetup.setup(
       'io.adafruit.com', 1883, CONFIG.Config.username, CONFIG.Config.apikey);
@@ -123,7 +115,7 @@ class MyApp extends StatelessWidget {
           'home': (context) => NestedTabBar(),
           'wrapper': (context) => Wrapper(),
           'navbar': (context) => NavigationBarController(),
-          'login': (context) => LoginPage(),
+          'login': (context) => LoginPage(onLoginSuccessCallback: onLoginCallbackToMain),
           'register': (context) => RegisterPage(),
           'roomview': (context) => RoomView(),
           'addRoomView': (context) => AddRoom(),
@@ -133,4 +125,15 @@ class MyApp extends StatelessWidget {
       ),
     );
   }
+}
+
+onLoginCallbackToMain(){
+  warningDataStream = UserService.getFireThresholdStream();
+  warningDataStream.listen((event) {
+    warningThreshold = event;
+  });
+  fireDataStream = UserService.getFireThresholdStream();
+  fireDataStream.listen((event) {
+    fireThreshold = event;
+  });
 }

--- a/fire_alarm_system/lib/model/service/user_service.dart
+++ b/fire_alarm_system/lib/model/service/user_service.dart
@@ -6,6 +6,10 @@ class UserService{
   static final FirebaseFirestore db = FirebaseFirestore.instance;
 
   static  Future<int> getFireThreshold() async{
+    if(FirebaseAuth.instance.currentUser == null){
+      print("fire null");
+      return 0;
+    }
     String uid = FirebaseAuth.instance.currentUser.uid;
     return (await db.collection('users').doc(uid).get())['fireThreshold'];
   }
@@ -16,6 +20,10 @@ class UserService{
   }
 
   static Future<int> getWarningThreshold() async{
+    if(FirebaseAuth.instance.currentUser == null){
+      print("warning null");
+      return 0;
+    }
     String uid = FirebaseAuth.instance.currentUser.uid;
     return (await db.collection('users').doc(uid).get())['warningThreshold'];
   }

--- a/fire_alarm_system/lib/ui/auth/screens/login.dart
+++ b/fire_alarm_system/lib/ui/auth/screens/login.dart
@@ -8,8 +8,9 @@ import 'package:flutter/material.dart';
 
 class LoginPage extends StatefulWidget {
   final Function toggleView;
+  var onLoginSuccessCallback;
 
-  LoginPage({this.toggleView});
+  LoginPage({this.toggleView, this.onLoginSuccessCallback});
 
   @override
   _LoginPageState createState() => _LoginPageState();
@@ -85,6 +86,9 @@ class _LoginPageState extends State<LoginPage> {
                           loading = false;
                           error = 'Could not sign in with those credentials';
                         });
+                      }
+                      else{
+                        widget.onLoginSuccessCallback();
                       }
                     }
                     //_validateLoginInput();


### PR DESCRIPTION
Login screen now take in an onLoginSuccessCallback to be run only after user logged in. This also fixed the bug where get<Fire/Warining>ThresholdStream will cause crash because uid is null when user not logged in at the beginning of main().